### PR TITLE
 Push image to GitHub Packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
       - master         # Push events on master branch
   pull_request:        # Run tests for any PRs
 
+env:
+  IMAGE_NAME: puppet-lint-action
+
 jobs:
   # Run tests.
   build:
@@ -42,3 +45,37 @@ jobs:
         uses: docker://github/super-linter:v2.2.0
         env:
           VALIDATE_ALL_CODEBASE: true
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.PUPPET_CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          SHA="${{ github.sha }}"
+          # Strip git ref prefix from version
+          REF=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          echo IMAGE_ID=$IMAGE_ID
+          echo SHA=$SHA
+          echo REF=$REF
+          docker tag $IMAGE_NAME $IMAGE_ID:$SHA
+          docker tag $IMAGE_NAME $IMAGE_ID:$REF
+          docker push $IMAGE_ID:$SHA
+          docker push $IMAGE_ID:$REF

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   # Run tests.
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:alpine
 LABEL name="puppet-lint-action"
 LABEL repository="https://github.com/ScottBrenner/puppet-lint-action"
 LABEL homepage="https://github.com/ScottBrenner/puppet-lint-action"
+LABEL org.opencontainers.image.source="https://github.com/ScottBrenner/puppet-lint-action"
 
 LABEL "com.github.actions.name"="puppet-lint-action"
 LABEL "com.github.actions.description"="GitHub Action for puppet-lint"


### PR DESCRIPTION
Updating the Actions workflow to push an image to GitHub Packages, copied from https://github.com/actions/starter-workflows/blob/d7ac62140faf23b67c29e892d4ce68342eb09609/ci/docker-publish.yml#L38-L77.