### PR TITLE
Fix ruby-json package dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL "com.github.actions.color"="orange"
 
 LABEL "maintainer"="Scott Brenner <scott@scottbrenner.me>"
 
-RUN apk --no-cache add ruby-json \
+RUN apk --no-cache add ruby-libs \
     && gem install puppet-lint --no-document
 
 COPY puppet-lint.json /puppet-lint.json


### PR DESCRIPTION
As of this week the puppet-lint-action was failing to build, apparently because the ruby-json package was pulled from the alpine repositories.

I found this notice in the release notes : 
`Subpackages ruby-bigdecimal, ruby-etc, ruby-fiddle, ruby-gdbm, ruby-io-console, ruby-irb, and ruby-json have been merged into ruby-libs. `
on https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.15.0#Ruby_3.0.2

So tested it and using ruby-libs does indeed seem to fix the issue (at least it did on our build).
